### PR TITLE
No need for explicit index on Resource properties

### DIFF
--- a/main/model.py
+++ b/main/model.py
@@ -77,11 +77,11 @@ class User(Base, modelx.UserX):
 class Resource(Base, modelx.ResourceX):
   user_key = ndb.KeyProperty(kind=User, required=True)
   blob_key = ndb.BlobKeyProperty(required=True)
-  name = ndb.StringProperty(indexed=True, required=True)
+  name = ndb.StringProperty(required=True)
   bucket_name = ndb.StringProperty()
   image_url = ndb.StringProperty(default='')
-  content_type = ndb.StringProperty(indexed=True, default='')
-  size = ndb.IntegerProperty(indexed=True, default=0)
+  content_type = ndb.StringProperty(default='')
+  size = ndb.IntegerProperty(default=0)
 
   _PROPERTIES = Base._PROPERTIES.union({
       'bucket_name',


### PR DESCRIPTION
Similar to https://github.com/gae-init/gae-init/pull/72, removing explicit `indexed=True` for Resource properties in model; since they are candidate for indexing by default anyway (see https://developers.google.com/appengine/docs/python/ndb/properties#options and https://developers.google.com/appengine/docs/python/datastore/typesandpropertyclasses)
