### PR TITLE
Using get_default_gcs_bucket_name to initialize the bucket

### DIFF
--- a/main/model.py
+++ b/main/model.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 
+from google.appengine.api import app_identity
 from google.appengine.ext import ndb
 
 import config
@@ -28,7 +29,8 @@ class Config(Base, modelx.ConfigX):
       'info', 'warning', 'success', 'danger',
     ])
   brand_name = ndb.StringProperty(default=config.APPLICATION_ID)
-  bucket_name = ndb.StringProperty(default='')
+  bucket_name = ndb.StringProperty(
+    default=app_identity.get_default_gcs_bucket_name())
   facebook_app_id = ndb.StringProperty(default='')
   facebook_app_secret = ndb.StringProperty(default='')
   feedback_email = ndb.StringProperty(default='')


### PR DESCRIPTION
Similar to https://github.com/gae-init/gae-init/pull/97 we can initialize the `Config.bucket_name` with something from the `app_identity` (as found in the `google.appengine.api`).

See https://developers.google.com/appengine/docs/python/googlecloudstorageclient/activate?hl=nl#Using_the_default_Gcs_bucket which also explains that **new** applications, since GAE Python SDK v1.9.0, receive a default bucket (with a free quota; I believe of 5 GB). For existing apps, the link provides instructions on how to create the Google Cloud Storage (GCS) bucket by hand.
