### PR TITLE
Changed style of encoding definition

### DIFF
--- a/main/resource.py
+++ b/main/resource.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 
 import urllib
 

--- a/main/serve.py
+++ b/main/serve.py
@@ -1,5 +1,8 @@
-import webapp2
+# coding: utf-8
+
 import urllib
+
+import webapp2
 from google.appengine.ext.webapp import blobstore_handlers
 from google.appengine.ext import blobstore
 


### PR DESCRIPTION
Similar to https://github.com/gae-init/gae-init-upload/commit/137184c255cd95bd1be4d6371f8bec94b7a826ee changed to using `# coding: utf-8` on top of .py files. Also added empty line in `import` area of `main/serve.py` as `urllib` is batteries included Python (see https://docs.python.org/2/library/urllib.html) while the other imports are GAE specific (following `gae-init` coding conventions for `import` sections).
