### PR TITLE
Avoid name clash (in derived projects)

### DIFF
--- a/main/resource.py
+++ b/main/resource.py
@@ -29,7 +29,7 @@ def resource_upload():
 
     if flask.request.path.startswith('/_s/'):
       urls = []
-      for _ in range(count):
+      for i in range(count):
         urls.append({'upload_url': blobstore.create_upload_url(
             flask.request.path,
             gs_bucket_name=gs_bucket_name,


### PR DESCRIPTION
Renamed the anonymous `_` variable to avoid name clash in derived (and translated) projects, when the `title='Resource Upload'` for the form is likely changed to `title=_('Resource Upload')` with a `from flask.ext.babel import lazy_gettext as _` in the import section.
